### PR TITLE
Cache query string params

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,7 @@ import FloatingActionButton from './FloatingActionButton'
 
 import Toolbar from './Toolbar'
 import Calendar from './Calendar'
-import { findPreviousState, getInitialState, setQueryParam, unsetQueryParam, fetchJsObject, stringToColor, parseEvents } from './utils'
+import { loadCachedQSIfNotExists, getInitialState, setQueryParam, unsetQueryParam, fetchJsObject, stringToColor, parseEvents } from './utils'
 
 import { ApplicationInsights } from '@microsoft/applicationinsights-web'
 import { ReactPlugin, withAITracking } from '@microsoft/applicationinsights-react-js'
@@ -59,7 +59,7 @@ let App = () => {
   )
   useEffect(() => localStorage.timeZone = timeZone, [timeZone])
 
-  findPreviousState()
+  loadCachedQSIfNotExists()
 
   const [y, s, m, h] = getInitialState()
 

--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,7 @@ import FloatingActionButton from './FloatingActionButton'
 
 import Toolbar from './Toolbar'
 import Calendar from './Calendar'
-import { getInitialState, setQueryParam, unsetQueryParam, fetchJsObject, stringToColor, parseEvents } from './utils'
+import { findPreviousState, getInitialState, setQueryParam, unsetQueryParam, fetchJsObject, stringToColor, parseEvents } from './utils'
 
 import { ApplicationInsights } from '@microsoft/applicationinsights-web'
 import { ReactPlugin, withAITracking } from '@microsoft/applicationinsights-react-js'
@@ -58,6 +58,8 @@ let App = () => {
     || 'Australia/Canberra' // Default to Canberra if API is missing (pre-2018 browsers)
   )
   useEffect(() => localStorage.timeZone = timeZone, [timeZone])
+
+  findPreviousState()
 
   const [y, s, m, h] = getInitialState()
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,6 +14,15 @@ export const stringToColor = str => {
   return stringColorMap[str]
 }
 
+// Finds a previous state and uses it if the url is empty
+export const findPreviousState = () => {
+  const qs = new URLSearchParams(window.location.search)
+
+  if (!qs.toString()) {
+    window.history.replaceState(null, '', '?' + localStorage.savedQueryParams);
+  }
+}
+
 // hardcode to semester 1 or 2 as users usually want them
 // allows app to function even if /sessions endpoint is down
 export const getInitialState = () => {
@@ -57,12 +66,14 @@ export const setQueryParam = (param, value) => {
   const qs = new URLSearchParams(window.location.search)
   qs.set(param, value ?? qs.get(param) ?? '') // if no value, just ensure param exists
   window.history.replaceState(null, '', '?'+qs.toString())
+  localStorage.savedQueryParams = qs.toString()
 }
 
 export const unsetQueryParam = param => {
   const qs = new URLSearchParams(window.location.search)
   qs.delete(param)
   window.history.replaceState(null, '', '?'+qs.toString())
+  localStorage.savedQueryParams = qs.toString()
 }
 
 export const getStartOfSession = () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,7 +15,7 @@ export const stringToColor = str => {
 }
 
 // Finds a previous state and uses it if the url is empty
-export const findPreviousState = () => {
+export const loadCachedQSIfNotExists = () => {
   const qs = new URLSearchParams(window.location.search)
 
   if (!qs.toString()) {


### PR DESCRIPTION
Fixes #124 

This is done by saving param changes to localstorage object "savedQueryParams". This is then read and applied when a user has a saved state and visits the site without any url parameters.