### PR TITLE
Fix warning about nested a tags

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -43,7 +43,7 @@ const formatEventContent = ({ selectOccurrence, resetOccurrence, hideOccurrence 
       <svg viewBox="0 0 24 24"><path d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"></path></svg>
     </div>
     <p>{event.title}</p>
-    <p>{locationLine}</p>
+    <object>{locationLine}</object>
     <p>{button}</p>
   </>
 }


### PR DESCRIPTION
Removes the slightly annoying warning by wrapping the inner a tag in an object tag.

This works because the object tag has its own local scope and as such the nested a tag no longer triggers a violation warning.