### PR TITLE
Add padding around course names

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -286,6 +286,10 @@ body[data-theme="dark"] {
   }
 }
 
+.rbt-token > a {
+  padding: 4px;
+}
+
 .fc-event-main object {
   width: 0;
   height: 0;


### PR DESCRIPTION
Fix this:
![](https://cdn.discordapp.com/attachments/930245506804908052/942347942466035752/unknown.png)
